### PR TITLE
Add d3dx9 to Witcher 2 (1207658930-gog)

### DIFF
--- a/1207658930-gog.json
+++ b/1207658930-gog.json
@@ -1,4 +1,8 @@
 {
   "title": "The Witcher 2: Assassins of Kings Enhanced Edition",
-  "winetricks": ["d3dcompiler_47", "mfc100", "d3dx9"]
+  "notes": {
+    "mfc100": "Fix launcher not starting",
+    "d3dx9_39": "Fix game not starting"
+  },
+  "winetricks": ["mfc100", "d3dx9_39"]
 }

--- a/1207658930-gog.json
+++ b/1207658930-gog.json
@@ -1,4 +1,4 @@
 {
   "title": "The Witcher 2: Assassins of Kings Enhanced Edition",
-  "winetricks": ["d3dcompiler_47", "mfc100"]
+  "winetricks": ["d3dcompiler_47", "mfc100", "d3dx9"]
 }


### PR DESCRIPTION
This fixes this in log:

```
029c:fixme:d3dx:D3DXLoadSurfaceFromMemory Unhandled filter 0x5.
029c:fixme:d3dx:D3DXLoadSurfaceFromMemory Unhandled filter 0x80004.
```