### PR TITLE
Remove entries that are handled by GOG manifest

### DIFF
--- a/1123662938-gog.json
+++ b/1123662938-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "SpellForce 2 - Anniversary Edition",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/1189268228-gog.json
+++ b/1189268228-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "STAR WARS™ - The Force Unleashed™ Ultimate Sith Edition",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/1193585573-gog.json
+++ b/1193585573-gog.json
@@ -1,7 +1,0 @@
-{
-  "title": "LEGO® Batman 2 DC Super Heroes™",
-  "notes": {
-    "d3dcompiler_47": "Fix visual glitches since the first screen (squares instead of real graphics)"
-  },
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/1207658859-gog.json
+++ b/1207658859-gog.json
@@ -1,8 +1,0 @@
-{
-  "title": "Empire Earth 3",
-  "notes": {
-    "physx": "Fix game crashing while booting",
-    "d3dx9_30": "Fix crash opening the setting and visual glitches in game"
-  },
-  "winetricks": ["physx", "d3dx9_30"]
-}

--- a/1207658930-gog.json
+++ b/1207658930-gog.json
@@ -1,8 +1,0 @@
-{
-  "title": "The Witcher 2: Assassins of Kings Enhanced Edition",
-  "notes": {
-    "mfc100": "Fix launcher not starting",
-    "d3dx9_39": "Fix game not starting"
-  },
-  "winetricks": ["mfc100", "d3dx9_39"]
-}

--- a/1207660473-gog.json
+++ b/1207660473-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "SpellForce 2: Demons Of The Past",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/1345182195-gog.json
+++ b/1345182195-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "Venetica - Gold Edition",
-  "winetricks": ["d3dcompiler_47", "physx"]
-}

--- a/1425039730-gog.json
+++ b/1425039730-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "Monkey Island™ 2 Special Edition: LeChuck’s Revenge™",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/1482504285-gog.json
+++ b/1482504285-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "Batman Arkham Asylum GOTY",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/1731318270-gog.json
+++ b/1731318270-gog.json
@@ -1,7 +1,0 @@
-{
-  "title": "LEGO® Star Wars™ - The Complete Saga",
-  "notes": {
-    "d3dcompiler_47": "Fix visual glitches since the first screen (squares instead of real graphics)"
-  },
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/1914219141-gog.json
+++ b/1914219141-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "SpellForce 2: Faith in Destiny",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/README.md
+++ b/README.md
@@ -102,25 +102,28 @@ When a fix is not needed anymore, remove the json file and strike-through the ti
 
 ### GOG:
 
+v2.13.0 means that the depednencies are installed automatically based on GOG manifest instead of using winetricks
+
+
 - Alien Breed: Impact
 - Alien Breed 2: Assault
 - Alien Breed 3: Descent
-- Batman Arkham Asylum Game of the Year Edition
+- ~Batman Arkham Asylum Game of the Year Edition~ (v2.13.0)
 - Beyond Good & Evil™
-- Empire Earth 3
+- ~Empire Earth 3~ (v2.13.0)
 - Ghost Master
 - Hitman: Absolution
 - Horizon Zero Dawn Complete Edition
-- LEGO® Batman 2 DC Super Heroes™
-- LEGO® Star Wars™ - The Complete Saga
-- Monkey Island™ 2 Special Edition: LeChuck’s Revenge™
-- SpellForce 2 - Anniversary Edition
-- SpellForce 2: Demons Of The Past
-- SpellForce 2: Faith in Destiny
-- STAR WARS™ - The Force Unleashed™ Ultimate Sith Edition
-- Venetica - Gold Edition
+- ~LEGO® Batman 2 DC Super Heroes™~ (v2.13.0)
+- ~LEGO® Star Wars™ - The Complete Saga~ (v2.13.0)
+- ~Monkey Island™ 2 Special Edition: LeChuck’s Revenge™~ (v2.13.0)
+- ~SpellForce 2 - Anniversary Edition~ (v2.13.0)
+- ~SpellForce 2: Demons Of The Past~ (v2.13.0)
+- ~SpellForce 2: Faith in Destiny~ (v2.13.0)
+- ~STAR WARS™ - The Force Unleashed™ Ultimate Sith Edition~ (v2.13.0)
+- ~Venetica - Gold Edition~ (v2.13.0)
 - The Expanse: A Telltale Series Deluxe Edition
 - The Witcher: Enhanced Edition
-- The Witcher 2: Assassins of Kings Enhanced Edition
+- ~The Witcher 2: Assassins of Kings Enhanced Edition~ (v2.13.0)
 
 ### Amazon:

--- a/gog/1123662938-gog.json
+++ b/gog/1123662938-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "SpellForce 2 - Anniversary Edition",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/gog/1189268228-gog.json
+++ b/gog/1189268228-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "STAR WARS™ - The Force Unleashed™ Ultimate Sith Edition",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/gog/1193585573-gog.json
+++ b/gog/1193585573-gog.json
@@ -1,7 +1,0 @@
-{
-  "title": "LEGO® Batman 2 DC Super Heroes™",
-  "notes": {
-    "d3dcompiler_47": "Fix visual glitches since the first screen (squares instead of real graphics)"
-  },
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/gog/1207658859-gog.json
+++ b/gog/1207658859-gog.json
@@ -1,8 +1,0 @@
-{
-  "title": "Empire Earth 3",
-  "notes": {
-    "physx": "Fix game crashing while booting",
-    "d3dx9_30": "Fix crash opening the setting and visual glitches in game"
-  },
-  "winetricks": ["physx", "d3dx9_30"]
-}

--- a/gog/1207658930-gog.json
+++ b/gog/1207658930-gog.json
@@ -1,8 +1,0 @@
-{
-  "title": "The Witcher 2: Assassins of Kings Enhanced Edition",
-  "notes": {
-    "mfc100": "Fix launcher not starting",
-    "d3dx9_39": "Fix game not starting"
-  },
-  "winetricks": ["mfc100", "d3dx9_39"]
-}

--- a/gog/1207660473-gog.json
+++ b/gog/1207660473-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "SpellForce 2: Demons Of The Past",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/gog/1345182195-gog.json
+++ b/gog/1345182195-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "Venetica - Gold Edition",
-  "winetricks": ["d3dcompiler_47", "physx"]
-}

--- a/gog/1425039730-gog.json
+++ b/gog/1425039730-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "Monkey Island™ 2 Special Edition: LeChuck’s Revenge™",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/gog/1482504285-gog.json
+++ b/gog/1482504285-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "Batman Arkham Asylum GOTY",
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/gog/1731318270-gog.json
+++ b/gog/1731318270-gog.json
@@ -1,7 +1,0 @@
-{
-  "title": "LEGO® Star Wars™ - The Complete Saga",
-  "notes": {
-    "d3dcompiler_47": "Fix visual glitches since the first screen (squares instead of real graphics)"
-  },
-  "winetricks": ["d3dcompiler_47"]
-}

--- a/gog/1914219141-gog.json
+++ b/gog/1914219141-gog.json
@@ -1,4 +1,0 @@
-{
-  "title": "SpellForce 2: Faith in Destiny",
-  "winetricks": ["d3dcompiler_47"]
-}


### PR DESCRIPTION
Removed entries that are already handled by GOG integration. In order to avoid redundancy