### PR TITLE
Europa Universalis 4: Install d3dcompiler_43

### DIFF
--- a/epic/da0103e959e54d139d0c109ded3b3672-epic.json
+++ b/epic/da0103e959e54d139d0c109ded3b3672-epic.json
@@ -1,4 +1,4 @@
 {
   "title": "Europa Universalis IV",
-  "winetricks": ["d3dx9_43"]
+  "winetricks": ["d3dx9_43", "d3dcompiler_43"]
 }


### PR DESCRIPTION
d3dcompiler_43 is required for the game to compile shaders correctly
~~d3dx9_43 is not required to my knowledge~~ d3dx9_43 is still required for the game to load d3dcompiler_43