### PR TITLE
add moonlighter to the repo with vcrun2017 to fix black screen on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ When a fix is not needed anymore, remove the json file and strike-through the ti
 - Horizon Zero Dawn Complete Edition
 - Hyper Light Drifter
 - Kao the Kangaroo
+- Moonlighter
 - MudRunner
 - Neverwinter
 - ~Next Up Hero~ (not needed anymore)
@@ -124,6 +125,7 @@ v2.13.0 means that the dependencies are installed automatically based on GOG man
 - Horizon Zero Dawn Complete Edition
 - ~LEGO® Batman 2 DC Super Heroes™~ (v2.13.0)
 - ~LEGO® Star Wars™ - The Complete Saga~ (v2.13.0)
+- Moonlighter
 - ~Monkey Island™ 2 Special Edition: LeChuck’s Revenge™~ (v2.13.0)
 - Nobody Wants to Die
 - ~SpellForce 2 - Anniversary Edition~ (v2.13.0)

--- a/epic/Eagle-epic.json
+++ b/epic/Eagle-epic.json
@@ -1,0 +1,8 @@
+{
+    "title": "Moonlighter",
+    "notes": {
+      "vcrun2017": "Solves the black screen on launch"
+    },
+    "winetricks": ["vcrun2017"]
+  }
+  

--- a/gog/2147483047-gog.json
+++ b/gog/2147483047-gog.json
@@ -1,0 +1,8 @@
+{
+    "title": "Moonlighter",
+    "notes": {
+      "vcrun2017": "Solves the black screen on launch"
+    },
+    "winetricks": ["vcrun2017"]
+  }
+  


### PR DESCRIPTION
vcrun2017 seems to be the only one required for this game, even though vcrun2013 and vcrun2015 are listed on the website. it also is needed for the GOG version, i'm not sure if i need to copy the file for that as well.