### PR TITLE
Revert "Add Sifu from Epic (d36336f190094951873ed6138ac208d8)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ When a fix is not needed anymore, remove the json file and strike-through the ti
 - Redout 2
 - Rogue Legacy
 - ~Shadow Tactics - Aiko's Choice~ (not needed anymore)
-- Sifu
 - Teenage Mutant Ninja Turtles: Shredder's Revenge
 - The Callisto Protocol
 - The Elder Scrolls Online

--- a/epic/d36336f190094951873ed6138ac208d8.json
+++ b/epic/d36336f190094951873ed6138ac208d8.json
@@ -1,7 +1,0 @@
-{
-  "title": "Sifu",
-  "notes": {
-    "vcrun2022": "Game fails to start with a message requiring Visual C runtime"
-  },
-  "winetricks": ["vcrun2022"]
-}


### PR DESCRIPTION
Reverts Heroic-Games-Launcher/known-fixes#11, since the game installs it through prereq installation and the known fixes happens afterward, this change effectively does nothing, so it's best to revert it for now or change the order so that known fixes happens before prereq installation