### PR TITLE
Added wikiLink fixes for Paradox Launcher issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,21 +121,25 @@ v2.13.0 means that the dependencies are installed automatically based on GOG man
 - Beyond Good & Evil™
 - Doom (2016)
 - ~Empire Earth 3~ (v2.13.0)
+- Europa Universalis IV
 - Evil West
 - Fahrenheit: Indigo Prophecy Remastered
 - Ghost Master
 - Heroes of Might and Magic® 3: Complete
 - Hitman: Absolution
 - Horizon Zero Dawn Complete Edition
+- Imperator: Rome
 - ~LEGO® Batman 2 DC Super Heroes™~ (v2.13.0)
 - ~LEGO® Star Wars™ - The Complete Saga~ (v2.13.0)
 - Moonlighter
 - ~Monkey Island™ 2 Special Edition: LeChuck’s Revenge™~ (v2.13.0)
 - Nobody Wants to Die
+- Prison Architect
 - ~SpellForce 2 - Anniversary Edition~ (v2.13.0)
 - ~SpellForce 2: Demons Of The Past~ (v2.13.0)
 - ~SpellForce 2: Faith in Destiny~ (v2.13.0)
 - ~STAR WARS™ - The Force Unleashed™ Ultimate Sith Edition~ (v2.13.0)
+- Stellaris
 - ~Venetica - Gold Edition~ (v2.13.0)
 - The Expanse: A Telltale Series Deluxe Edition
 - The Witcher: Enhanced Edition

--- a/gog/1441974651-gog.json
+++ b/gog/1441974651-gog.json
@@ -1,0 +1,4 @@
+{
+  "title": "Prison Architect",
+  "wikiLink": "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Paradox-Launcher-for-native-Linux-games-from-GOG"
+}

--- a/gog/1508702879-gog.json
+++ b/gog/1508702879-gog.json
@@ -1,0 +1,4 @@
+{
+  "title": "Stellaris",
+  "wikiLink": "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Paradox-Launcher-for-native-Linux-games-from-GOG"
+}

--- a/gog/2057001589-gog.json
+++ b/gog/2057001589-gog.json
@@ -1,0 +1,4 @@
+{
+  "title": "Europa Universalis IV",
+  "wikiLink": "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Paradox-Launcher-for-native-Linux-games-from-GOG"
+}

--- a/gog/2131232214-gog.json
+++ b/gog/2131232214-gog.json
@@ -1,0 +1,4 @@
+{
+  "title": "Imperator: Rome",
+  "wikiLink": "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Paradox-Launcher-for-native-Linux-games-from-GOG"
+}


### PR DESCRIPTION
Adds wikiLink references to an issue with the Paradox Launcher startup in Heroic flatpak for four affected titles on GOG.