### PR TITLE
Add The Elder Scrolls V: Skyrim Special Edition from EGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ When a fix is not needed anymore, remove the json file and strike-through the ti
 - Teenage Mutant Ninja Turtles: Shredder's Revenge
 - The Callisto Protocol
 - The Elder Scrolls Online
+- The Elder Scrolls V: Skyrim Special Edition
 - The Expanse: A Telltale Series
 - The Last of Us Part I
 - Thief

--- a/ac82db5035584c7f8a2c548d98c86b2c-epic.json
+++ b/ac82db5035584c7f8a2c548d98c86b2c-epic.json
@@ -1,7 +1,0 @@
-{
-  "title": "The Elder Scrolls V: Skyrim Special Edition",
-  "notes": {
-    "xact_x64": "NPC voices and music is missing without it."
-  },
-  "winetricks": ["xact_x64"]
-}

--- a/ac82db5035584c7f8a2c548d98c86b2c-epic.json
+++ b/ac82db5035584c7f8a2c548d98c86b2c-epic.json
@@ -1,0 +1,7 @@
+{
+  "title": "The Elder Scrolls V: Skyrim Special Edition",
+  "notes": {
+    "xact_x64": "NPC voices and music is missing without it."
+  },
+  "winetricks": ["xact_x64"]
+}


### PR DESCRIPTION
Without this, npc voices and music are missing. Tested with Proton GE 10-1.