### PR TITLE
Add fix for Two Worlds Epic Edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ v2.13.0 means that the dependencies are installed automatically based on GOG man
 - The Witcher: Enhanced Edition
 - ~The Witcher 2: Assassins of Kings Enhanced Edition~ (v2.13.0)
 - THIEF: Definitive Edition
+- Two Worlds Epic Edition
 - Tzar: The Burden of the Crown
 - Warhammer: Shadow of the Horned Rat
 - XCOM® 2

--- a/gog/1207658861-gog.json
+++ b/gog/1207658861-gog.json
@@ -1,0 +1,7 @@
+{
+  "title": "Two Worlds Epic Edition",
+  "notes": {
+      "wmp9": "Required for game to start correctly"
+  },
+  "winetricks": ["wmp9"]
+}


### PR DESCRIPTION
_Two Worlds Epic Edition_ requires Windows Media Player 9 in order to start. ProtonDB suggests that `xact` might also be helpful, but I haven't investigated this. The game seems to work without it.